### PR TITLE
Use Python 3.5 instead of 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.5
 
 MAINTAINER libcrack <devnull@libcrack.so>
 


### PR DESCRIPTION
Limnoria supports Python 3 better than 2.7 for awhile now.

Note that I have no idea how to use Docker, so I am not sure this patch will work.